### PR TITLE
Command line arguments changed to work with

### DIFF
--- a/maintenance_mode/management/commands/maintenance_mode.py
+++ b/maintenance_mode/management/commands/maintenance_mode.py
@@ -2,21 +2,34 @@
 
 from __future__ import absolute_import
 
+import django
 from django.core.management.base import BaseCommand
 
-from maintenance_mode import core
+from maintenance_mode import core, __version__
 
 
 class Command(BaseCommand):
     
     args = '<on|off>'
     help = 'run python manage.py maintenance_mode %s to change maintenance-mode state' % args
+    missing_args_message = "Specify one of %s" % args
     
+    def get_version(self):
+        return __version__
+
+    def add_arguments(self, parser):
+            parser.add_argument(
+                'flag',
+                help=self.args
+            )
+
     def handle(self, *args, **options):
+
+        flag = options["flag"]
         
-        if len(args) > 0:
+        if flag:
             
-            arg_value = args[0].lower()
+            arg_value = flag.lower()
             
             if arg_value in ['on', 'yes', 'true', '1']:
                 core.set_maintenance_mode(True)


### PR DESCRIPTION
Command line management modified to work with
Python 3.5.3 and Django 1.10.5,
as described in:
https://docs.djangoproject.com/en/1.10/howto/custom-management-commands/
Changes should work with older versions of Python and Django.

- get_version method overloaded to return maintenance_mode version
  instead of django version
- add_arguments method overloaded to add a new positional argument to
  store the on/off flag
- missing_args_message defined to have a better error message
- handle method modified to use options["flags"]

Thanks,
Francesco