### PR TITLE
Integrate mode settings into core

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All these settings are optional, if not defined in ``settings.py`` the default v
 
 ```python
 # if True the maintenance-mode will be activated
-MAINTENANCE_MODE = False
+MAINTENANCE_MODE = None
 ```
 
 ```python

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ default values (listed below) will be used.
 .. code:: python
 
     # if True the maintenance-mode will be activated
-    MAINTENANCE_MODE = False
+    MAINTENANCE_MODE = None
 
 .. code:: python
 

--- a/maintenance_mode/core.py
+++ b/maintenance_mode/core.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
+from django.core.exceptions import ImproperlyConfigured
 
 from maintenance_mode import io, settings
 
 
 def get_maintenance_mode():
+    # If maintenance mode is defined in settings, it has priority.
+    if settings.MAINTENANCE_MODE is not None:
+        return settings.MAINTENANCE_MODE
 
     value = io.read_file(settings.MAINTENANCE_MODE_STATE_FILE_PATH, '0')
 
@@ -15,6 +19,9 @@ def get_maintenance_mode():
 
 
 def set_maintenance_mode(value):
+    # If maintenance mode is defined in settings, it can't be changed.
+    if settings.MAINTENANCE_MODE is not None:
+        raise ImproperlyConfigured('Maintenance mode cannot be set dynamically if defined in settings.')
 
     if not isinstance(value, bool):
         raise TypeError('value argument type is not boolean')

--- a/maintenance_mode/middleware.py
+++ b/maintenance_mode/middleware.py
@@ -23,10 +23,7 @@ class MaintenanceModeMiddleware(__MaintenanceModeMiddlewareBaseClass):
 
     def process_request(self, request):
 
-        is_maintenance_mode = settings.MAINTENANCE_MODE \
-            or core.get_maintenance_mode()
-
-        if not is_maintenance_mode:
+        if not core.get_maintenance_mode():
             return None
 
         try:

--- a/maintenance_mode/settings.py
+++ b/maintenance_mode/settings.py
@@ -6,7 +6,7 @@ import os
 
 
 MAINTENANCE_MODE = getattr(
-    settings, 'MAINTENANCE_MODE', False)
+    settings, 'MAINTENANCE_MODE', None)
 MAINTENANCE_MODE_GET_CLIENT_IP_ADDRESS = getattr(
     settings, 'MAINTENANCE_MODE_GET_CLIENT_IP_ADDRESS', None)
 MAINTENANCE_MODE_GET_TEMPLATE_CONTEXT = getattr(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -116,7 +116,7 @@ class MaintenanceModeTestCase(TestCase):
 
     def __reset_state(self):
 
-        settings.MAINTENANCE_MODE = False
+        settings.MAINTENANCE_MODE = None
         core.set_maintenance_mode(False)
 
         try:
@@ -166,6 +166,28 @@ class MaintenanceModeTestCase(TestCase):
         core.set_maintenance_mode(False)
         val = core.get_maintenance_mode()
         self.assertFalse(val)
+
+    def test_core_maintenance_enabled(self):
+        # Test `get_maintenance_mode` returns maintenance mode from settings - enabled
+        self.__reset_state()
+        core.set_maintenance_mode(False)  # Disable maintenance mode in lock file
+        settings.MAINTENANCE_MODE = True
+        val = core.get_maintenance_mode()
+        self.assertTrue(val)
+
+    def test_core_maintenance_disabled(self):
+        # Test `get_maintenance_mode` returns maintenance mode from settings - disabled
+        self.__reset_state()
+        core.set_maintenance_mode(True)  # Enable maintenance mode in lock file
+        settings.MAINTENANCE_MODE = False
+        val = core.get_maintenance_mode()
+        self.assertFalse(val)
+
+    def test_core_set_disabled(self):
+        # Test `set_maintenance_mode` is disable if maintenance mode is set in settings.
+        self.__reset_state()
+        settings.MAINTENANCE_MODE = True
+        self.assertRaises(ImproperlyConfigured, core.set_maintenance_mode, True)
 
     def test_core_invalid_argument(self):
 


### PR DESCRIPTION
To clean API, the `core` functions should behave according to the `MAINTENANCE_MODE` setting. To allow that the default changes to `None`.