### PR TITLE
Bugfix #26 adl allow override settings

### DIFF
--- a/maintenance_mode/__init__.py
+++ b/maintenance_mode/__init__.py
@@ -1,0 +1,1 @@
+import settings

--- a/maintenance_mode/__init__.py
+++ b/maintenance_mode/__init__.py
@@ -1,1 +1,1 @@
-import settings
+from . import settings

--- a/maintenance_mode/core.py
+++ b/maintenance_mode/core.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from maintenance_mode import io, settings
+from maintenance_mode import io
 
 
 def get_maintenance_mode():

--- a/maintenance_mode/http.py
+++ b/maintenance_mode/http.py
@@ -2,13 +2,12 @@
 
 """HTTP response utilities."""
 import django
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import render, redirect
 from django.template import RequestContext
 from django.utils.cache import add_never_cache_headers
 from django.utils.module_loading import import_string
-
-from maintenance_mode import settings
 
 
 def get_maintenance_response(request):

--- a/maintenance_mode/middleware.py
+++ b/maintenance_mode/middleware.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import django
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch, resolve, reverse
 from django.utils.module_loading import import_string
@@ -12,7 +13,7 @@ else:
     from django.utils.deprecation import MiddlewareMixin
     __MaintenanceModeMiddlewareBaseClass = MiddlewareMixin
 
-from maintenance_mode import core, settings, utils
+from maintenance_mode import core, utils
 from maintenance_mode.http import get_maintenance_response
 
 import re

--- a/maintenance_mode/settings.py
+++ b/maintenance_mode/settings.py
@@ -4,28 +4,27 @@ from django.conf import settings
 
 import os
 
-
-MAINTENANCE_MODE = getattr(
-    settings, 'MAINTENANCE_MODE', None)
-MAINTENANCE_MODE_GET_CLIENT_IP_ADDRESS = getattr(
-    settings, 'MAINTENANCE_MODE_GET_CLIENT_IP_ADDRESS', None)
-MAINTENANCE_MODE_GET_TEMPLATE_CONTEXT = getattr(
-    settings, 'MAINTENANCE_MODE_GET_TEMPLATE_CONTEXT', None)
-MAINTENANCE_MODE_IGNORE_IP_ADDRESSES = getattr(
-    settings, 'MAINTENANCE_MODE_IGNORE_IP_ADDRESSES', None)
-MAINTENANCE_MODE_IGNORE_STAFF = getattr(
-    settings, 'MAINTENANCE_MODE_IGNORE_STAFF', False)
-MAINTENANCE_MODE_IGNORE_SUPERUSER = getattr(
-    settings, 'MAINTENANCE_MODE_IGNORE_SUPERUSER', False)
-MAINTENANCE_MODE_IGNORE_TESTS = getattr(
-    settings, 'MAINTENANCE_MODE_IGNORE_TESTS', False)
-MAINTENANCE_MODE_IGNORE_URLS = getattr(
-    settings, 'MAINTENANCE_MODE_IGNORE_URLS', None)
-MAINTENANCE_MODE_REDIRECT_URL = getattr(
-    settings, 'MAINTENANCE_MODE_REDIRECT_URL', None)
-MAINTENANCE_MODE_STATE_FILE_PATH = getattr(
-    settings, 'MAINTENANCE_MODE_STATE_FILE_PATH',
-    os.path.join(os.path.abspath(
-        os.path.dirname(__file__)), 'maintenance_mode_state.txt'))
-MAINTENANCE_MODE_TEMPLATE = getattr(
-    settings, 'MAINTENANCE_MODE_TEMPLATE', '503.html')
+if not hasattr(settings, 'MAINTENANCE_MODE'):
+    settings.MAINTENANCE_MODE = None
+if not hasattr(settings, 'MAINTENANCE_MODE_GET_CLIENT_IP_ADDRESS'):
+    settings.MAINTENANCE_MODE_GET_CLIENT_IP_ADDRESS = None
+if not hasattr(settings, 'MAINTENANCE_MODE_GET_TEMPLATE_CONTEXT'):
+    settings.MAINTENANCE_MODE_GET_TEMPLATE_CONTEXT = None
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_IP_ADDRESSES'):
+    settings.MAINTENANCE_MODE_IGNORE_IP_ADDRESSES = None
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_STAFF'):
+    settings.MAINTENANCE_MODE_IGNORE_STAFF = False
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_SUPERUSER'):
+    settings.MAINTENANCE_MODE_IGNORE_SUPERUSER = False
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_TESTS'):
+    settings.MAINTENANCE_MODE_IGNORE_TESTS = False
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_URLS'):
+    settings.MAINTENANCE_MODE_IGNORE_URLS = None
+if not hasattr(settings, 'MAINTENANCE_MODE_REDIRECT_URL'):
+    settings.MAINTENANCE_MODE_REDIRECT_URL = None
+if not hasattr(settings, 'MAINTENANCE_MODE_STATE_FILE_PATH'):
+    settings.MAINTENANCE_MODE_STATE_FILE_PATH = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)),
+        'maintenance_mode_state.txt')
+if not hasattr(settings, 'MAINTENANCE_MODE_TEMPLATE'):
+    settings.MAINTENANCE_MODE_TEMPLATE = '503.html'

--- a/maintenance_mode/version.py
+++ b/maintenance_mode/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.6.6'
+__version__ = '0.6.7'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import django
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
@@ -13,7 +14,7 @@ if django.VERSION < (1, 10):
 else:
     from django.urls import reverse
 
-from maintenance_mode import core, http, io, middleware, settings, utils, views
+from maintenance_mode import core, http, io, middleware, utils, views
 
 import os
 import re


### PR DESCRIPTION
This will allow parent projects using @override_settings (or similar) to properly override django-maintenace-mode settings.

This has been tested both within the django-maintenance-mode project and also with a parent project. Backwards compatible with no breaking changes.