### PR TITLE
Allow lazy ignore-URLs (like django.urls.reverse_lazy)

### DIFF
--- a/maintenance_mode/middleware.py
+++ b/maintenance_mode/middleware.py
@@ -93,7 +93,9 @@ class MaintenanceModeMiddleware(__MaintenanceModeMiddlewareBaseClass):
 
             for url in settings.MAINTENANCE_MODE_IGNORE_URLS:
 
-                url_re = re.compile(str(url))
+                if not isinstance(r, re._pattern_type):
+                    url = str(url)
+                url_re = re.compile(url)
 
                 if url_re.match(request.path_info):
                     return None

--- a/maintenance_mode/middleware.py
+++ b/maintenance_mode/middleware.py
@@ -93,7 +93,7 @@ class MaintenanceModeMiddleware(__MaintenanceModeMiddlewareBaseClass):
 
             for url in settings.MAINTENANCE_MODE_IGNORE_URLS:
 
-                if not isinstance(r, re._pattern_type):
+                if not isinstance(url, re._pattern_type):
                     url = str(url)
                 url_re = re.compile(url)
 

--- a/maintenance_mode/middleware.py
+++ b/maintenance_mode/middleware.py
@@ -93,7 +93,7 @@ class MaintenanceModeMiddleware(__MaintenanceModeMiddlewareBaseClass):
 
             for url in settings.MAINTENANCE_MODE_IGNORE_URLS:
 
-                url_re = re.compile(url)
+                url_re = re.compile(str(url))
 
                 if url_re.match(request.path_info):
                     return None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -465,10 +465,6 @@ class MaintenanceModeTestCase(TestCase):
         response = self.middleware.process_request(request)
         self.assertEqual(response, None)
 
-        settings.MAINTENANCE_MODE_IGNORE_URLS = None
-        response = self.middleware.process_request(request)
-        self.assertMaintenanceMode(response)
-
         class LazyUrl:
             def __init__(self, url):
                 self.url = url
@@ -479,6 +475,10 @@ class MaintenanceModeTestCase(TestCase):
         settings.MAINTENANCE_MODE_IGNORE_URLS = (LazyUrl('/'), )
         response = self.middleware.process_request(request)
         self.assertEqual(response, None)
+
+        settings.MAINTENANCE_MODE_IGNORE_URLS = None
+        response = self.middleware.process_request(request)
+        self.assertMaintenanceMode(response)
 
     def test_middleware_redirect_url(self):
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -469,6 +469,17 @@ class MaintenanceModeTestCase(TestCase):
         response = self.middleware.process_request(request)
         self.assertMaintenanceMode(response)
 
+        class LazyUrl:
+            def __init__(self, url):
+                self.url = url
+
+            def __str__(self):
+                return self.url
+
+        settings.MAINTENANCE_MODE_IGNORE_URLS = (LazyUrl('/'), )
+        response = self.middleware.process_request(request)
+        self.assertEqual(response, None)
+
     def test_middleware_redirect_url(self):
 
         self.__reset_state()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,9 +10,9 @@ from django.test import Client, override_settings, RequestFactory, \
     SimpleTestCase, TestCase
 
 if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse
+    from django.core.urlresolvers import reverse, reverse_lazy
 else:
-    from django.urls import reverse
+    from django.urls import reverse, reverse_lazy
 
 from maintenance_mode import core, http, io, middleware, utils, views
 
@@ -473,6 +473,10 @@ class MaintenanceModeTestCase(TestCase):
                 return self.url
 
         settings.MAINTENANCE_MODE_IGNORE_URLS = (LazyUrl('/'), )
+        response = self.middleware.process_request(request)
+        self.assertEqual(response, None)
+
+        settings.MAINTENANCE_MODE_IGNORE_URLS = (reverse_lazy('root'), )
         response = self.middleware.process_request(request)
         self.assertEqual(response, None)
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -11,7 +11,7 @@ from django.http import HttpResponse
 
 
 urlpatterns = [
-    re_path(r'^$', lambda x: HttpResponse()),
+    re_path(r'^$', lambda x: HttpResponse(), name='root'),
     re_path(r'^maintenance-mode-redirect/$', lambda x: HttpResponse(), name='maintenance_mode_redirect'),
     re_path(r'^maintenance-mode/', include('maintenance_mode.urls')),
 ]


### PR DESCRIPTION
We currently can't add reverse URLs to the ignore-list in settings before URLConf has been loaded, currently `re.compile` does a type-check and fails (lazy functionals aren't strings), i.e.
```
MAINTENANCE_MODE_IGNORE_URLS = [reverse_lazy('user:login')]
```
fails.

If instead we do `re.compile(str(url))` the URL is reversed just-in-time.