### PR TITLE
Leave django admin open - settings flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ MAINTENANCE_MODE_IGNORE_URLS = ()
 # useful for running tests while maintenance mode is on, before opening the site to public use
 MAINTENANCE_MODE_IGNORE_TESTS = False
 ```
+```python
+# if True the maintenance mode will not return 503 response when working with django-admin
+# useful if you want to keep your administration area available to your editors
+MAINTENANCE_MODE_IGNORE_ADMIN_SITES = False
+```
 
 ```python
 # the absolute url where users will be redirected to during maintenance-mode

--- a/maintenance_mode/http.py
+++ b/maintenance_mode/http.py
@@ -123,6 +123,10 @@ def need_maintenance_response(request):
                 and request.user.is_superuser:
             return False
 
+    if settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES:
+        if request.path and request.path.startswith(reverse('admin:index')):
+            return False
+
     if settings.MAINTENANCE_MODE_IGNORE_TESTS:
 
         is_testing = False

--- a/maintenance_mode/http.py
+++ b/maintenance_mode/http.py
@@ -124,8 +124,10 @@ def need_maintenance_response(request):
             return False
 
     if settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITE:
+        # Maybe django-admin is not enabled so we need to try/except the reverse()
         try:
-            if request.path and request.path.startswith(reverse('admin:index')):
+            admin_url = reverse('admin:index')
+            if request.path and request.path.startswith(admin_url):
                 return False
         except NoReverseMatch:
             pass

--- a/maintenance_mode/http.py
+++ b/maintenance_mode/http.py
@@ -123,9 +123,12 @@ def need_maintenance_response(request):
                 and request.user.is_superuser:
             return False
 
-    if settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES:
-        if request.path and request.path.startswith(reverse('admin:index')):
-            return False
+    if settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITE:
+        try:
+            if request.path and request.path.startswith(reverse('admin:index')):
+                return False
+        except NoReverseMatch:
+            pass
 
     if settings.MAINTENANCE_MODE_IGNORE_TESTS:
 

--- a/maintenance_mode/settings.py
+++ b/maintenance_mode/settings.py
@@ -30,6 +30,9 @@ if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_STAFF'):
 if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_SUPERUSER'):
     settings.MAINTENANCE_MODE_IGNORE_SUPERUSER = False
 
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_ADMIN_SITES'):
+    settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES = False
+
 if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_TESTS'):
     settings.MAINTENANCE_MODE_IGNORE_TESTS = False
 

--- a/maintenance_mode/settings.py
+++ b/maintenance_mode/settings.py
@@ -30,8 +30,8 @@ if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_STAFF'):
 if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_SUPERUSER'):
     settings.MAINTENANCE_MODE_IGNORE_SUPERUSER = False
 
-if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_ADMIN_SITES'):
-    settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES = False
+if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_ADMIN_SITE'):
+    settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITE = False
 
 if not hasattr(settings, 'MAINTENANCE_MODE_IGNORE_TESTS'):
     settings.MAINTENANCE_MODE_IGNORE_TESTS = False

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -679,6 +679,54 @@ class MaintenanceModeTestCase(TestCase):
         response = self.middleware.process_request(request)
         self.assertMaintenanceResponse(response)
 
+    def test_middleware_ignore_admin_site_on_admin_site_with_admin_flag_true(self):
+
+        self.__reset_state()
+
+        settings.MAINTENANCE_MODE = True
+
+        # Admin site request
+        request = self.__get_superuser_request('/admin')
+        settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES = True
+        response = self.middleware.process_request(request)
+        self.assertEqual(response, None)
+
+    def test_middleware_ignore_admin_site_on_admin_site_with_admin_flag_false(self):
+
+        self.__reset_state()
+
+        settings.MAINTENANCE_MODE = True
+
+        # Admin site request
+        request = self.__get_superuser_request('/admin')
+        settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES = False
+        response = self.middleware.process_request(request)
+        self.assertMaintenanceResponse(response)
+
+    def test_middleware_ignore_admin_site_on_any_site_with_admin_flag_true(self):
+
+        self.__reset_state()
+
+        settings.MAINTENANCE_MODE = True
+
+        # Admin site request
+        request = self.__get_superuser_request('/')
+        settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES = True
+        response = self.middleware.process_request(request)
+        self.assertMaintenanceResponse(response)
+
+    def test_middleware_ignore_admin_site_on_any_site_with_admin_flag_false(self):
+
+        self.__reset_state()
+
+        settings.MAINTENANCE_MODE = True
+
+        # Admin site request
+        request = self.__get_superuser_request('/')
+        settings.MAINTENANCE_MODE_IGNORE_ADMIN_SITES = False
+        response = self.middleware.process_request(request)
+        self.assertMaintenanceResponse(response)
+
     def test_middleware_ignore_tests(self):
 
         self.__reset_state()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -39,10 +39,18 @@ def get_template_context(request):
 
 
 @override_settings(
+    INSTALLED_APPS=[
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.messages',
+        'django.contrib.admin',
+    ],
     MIDDLEWARE_CLASSES=[
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
 
         'maintenance_mode.middleware.MaintenanceModeMiddleware',
     ],
@@ -51,7 +59,9 @@ def get_template_context(request):
     # for django < 1.8
     TEMPLATE_CONTEXT_PROCESSORS=(
         'django.contrib.auth.context_processors.auth',
+        'django.contrib.messages.context_processors.messages',
         'django.core.context_processors.request',
+
         'maintenance_mode.context_processors.maintenance_mode',
     ),
 


### PR DESCRIPTION
Added new settings flag to be able to leave the django admin open while shutting down the rest of the site.