### PR TITLE
Adds setting 'MAINTENANCE_MODE_STATUS_CODE' (default 503)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ MAINTENANCE_MODE_TEMPLATE = '503.html'
 MAINTENANCE_MODE_GET_TEMPLATE_CONTEXT = None
 ```
 
+```python
+# the HTTP status code to send
+MAINTENANCE_MODE_STATUS_CODE = 503
+```
+
 #### URLs
 Add **maintenance_mode.urls** to ``urls.py`` if you want superusers able to set maintenance_mode using urls.
 

--- a/maintenance_mode/http.py
+++ b/maintenance_mode/http.py
@@ -58,7 +58,8 @@ def get_maintenance_response(request):
         kwargs = {'context': context}
 
     response = render(request, settings.MAINTENANCE_MODE_TEMPLATE,
-                      status=503, **kwargs)
+                      status=settings.MAINTENANCE_MODE_STATUS_CODE,
+                      **kwargs)
 
     add_never_cache_headers(response)
     return response

--- a/maintenance_mode/settings.py
+++ b/maintenance_mode/settings.py
@@ -58,3 +58,6 @@ if not hasattr(settings, 'MAINTENANCE_MODE_STATE_FILE_PATH'):
 
 if not hasattr(settings, 'MAINTENANCE_MODE_TEMPLATE'):
     settings.MAINTENANCE_MODE_TEMPLATE = '503.html'
+
+if not hasattr(settings, 'MAINTENANCE_MODE_STATUS_CODE'):
+    settings.MAINTENANCE_MODE_STATUS_CODE = 503

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -121,7 +121,7 @@ class MaintenanceModeTestCase(TestCase):
     def assertMaintenanceResponse(self, response):
         self.assertTemplateUsed(settings.MAINTENANCE_MODE_TEMPLATE)
         if django.VERSION >= (1, 8):
-            self.assertEqual(response.status_code, 503)
+            self.assertEqual(response.status_code, settings.MAINTENANCE_MODE_STATUS_CODE)
 
     def assertOkResponse(self, response):
         self.assertEqual(response.status_code, 200)
@@ -1005,7 +1005,8 @@ class TestGetMaintenanceResponse(SimpleTestCase):
             RequestFactory().get('/dummy/'))
 
         self.assertContains(
-            response, 'django-maintenance-mode', status_code=503)
+            response, 'django-maintenance-mode',
+            status_code=settings.MAINTENANCE_MODE_STATUS_CODE)
         self.assertIn('max-age=0', response['Cache-Control'])
 
     def test_custom_context(self):
@@ -1017,7 +1018,8 @@ class TestGetMaintenanceResponse(SimpleTestCase):
             RequestFactory().get('/dummy/'))
 
         self.assertContains(
-            response, 'django-maintenance-mode', status_code=503)
+            response, 'django-maintenance-mode',
+            status_code=settings.MAINTENANCE_MODE_STATUS_CODE)
         self.assertIn('max-age=0', response['Cache-Control'])
 
     def test_invalid_context_function(self):


### PR DESCRIPTION
In some restricted environments such as AWS Elastic Beanstalk, 5xx
responses are treated as errors in health checks. A user may therefore
wish to return e.g. HTTP 200 instead.

Fixes #53