### PR TITLE
Added an S3 file backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 # PyBuilder
 target/
 maintenance_mode_state.txt
+
+# IDE
+.idea

--- a/maintenance_mode/backends.py
+++ b/maintenance_mode/backends.py
@@ -33,11 +33,11 @@ class LocalFileBackend(AbstractStateBackend):
         write_file(settings.MAINTENANCE_MODE_STATE_FILE_PATH, value)
 
 
-class S3FileBackend(AbstractStateBackend):
+class DefaultStorageBackend(AbstractStateBackend):
 
     def get_value(self):
         try:
-            value = default_storage.open(settings.MAINTENANCE_MODE_STATE_FILE_NAME).read()
+            value = str(int(default_storage.open(settings.MAINTENANCE_MODE_STATE_FILE_NAME).read()))
         except IOError:
             return False
         if value not in ['0', '1']:

--- a/maintenance_mode/backends.py
+++ b/maintenance_mode/backends.py
@@ -2,6 +2,9 @@
 
 from django.conf import settings
 
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
 from maintenance_mode.io import read_file, write_file
 
 
@@ -29,3 +32,21 @@ class LocalFileBackend(AbstractStateBackend):
             raise ValueError('state file content value is not 0|1')
         write_file(settings.MAINTENANCE_MODE_STATE_FILE_PATH, value)
 
+
+class S3FileBackend(AbstractStateBackend):
+
+    def get_value(self):
+        try:
+            value = default_storage.open(settings.MAINTENANCE_MODE_STATE_FILE_NAME).read()
+        except IOError:
+            return False
+        if value not in ['0', '1']:
+            raise ValueError('state file content value is not 0|1')
+        value = bool(int(value))
+        return value
+
+    def set_value(self, value):
+        value = str(int(value))
+        if value not in ['0', '1']:
+            raise ValueError('state file content value is not 0|1')
+        default_storage.save(settings.MAINTENANCE_MODE_STATE_FILE_NAME, ContentFile(value))

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     download_url='%s/%s/archive/%s.tar.gz' % (github_url, package_name, __version__, ),
     keywords=['django', 'maintenance', 'mode', 'offline', 'under', '503', 'service', 'temporarily', 'unavailable'],
     requires=['django(>=1.7)'],
+    tests_require=['mock'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist =
     py27-{dj17,dj18,dj19,dj110,dj111},
     py34-{dj17,dj18,dj19,dj110,dj111,dj20},
-    py35-{dj18,dj19,dj110,dj111,dj20,dj21,djmaster},
-    py36-{dj18,dj19,dj110,dj111,dj20,dj21,djmaster},
-    py37-{dj20,dj21,djmaster},
+    py35-{dj18,dj19,dj110,dj111,dj20,dj21,dj22},
+    py36-{dj18,dj19,dj110,dj111,dj20,dj21,dj22},
+    py37-{dj20,dj21,dj22},
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
@@ -15,7 +15,8 @@ deps =
     dj111: Django >= 1.11, < 1.12
     dj20: Django >= 2.0, < 2.1
     dj21: Django >= 2.1, < 2.2
-    djmaster: https://github.com/django/django/archive/master.tar.gz
+    dj22: Django >= 2.2, < 2.3
+;    djmaster: https://github.com/django/django/archive/master.tar.gz
     coverage
     codecov
 commands =


### PR DESCRIPTION
If running a system with multiple servers you need a shared place to maintain state. S3 is perfect for this because as part of maintenance you may be modifying your cache or database so S3 could maintain state throughout such changes.