### PR TITLE
Remove CONTEXT_PROCESSORS reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ It doesn't use database and doesn't prevent database access.
 1. Run ``pip install django-maintenance-mode`` or [download django-maintenance-mode](http://pypi.python.org/pypi/django-maintenance-mode) and add the **maintenance_mode** package to your project
 2. Add ``'maintenance_mode'`` to ``settings.INSTALLED_APPS`` before custom applications
 3. Add ``'maintenance_mode.middleware.MaintenanceModeMiddleware'`` to ``settings.MIDDLEWARE_CLASSES``/``settings.MIDDLEWARE`` as last middleware
-4. Add ``'maintenance_mode.context_processors.maintenance_mode'`` to ``settings.CONTEXT_PROCESSORS``
-5. Add your custom ``templates/503.html`` file
-6. Restart your application server
+4. Add your custom ``templates/503.html`` file
+5. Restart your application server
 
 ## Configuration (optional)
 


### PR DESCRIPTION
My rationale for the PR:
* The mention of `CONTEXT_PROCESSORS` appears to be a mistake (it is not a stock Django setting; closest is `TEMPLATE_CONTEXT_PROCESSORS` in the 1.x line, which is out of support).
* The correct method of updating the template context processors setting is shown already, with example code, later in the doc. 
* Adding the context processor is not needed for basic operation, unlike the other steps under "Installation".

I hope this change is reasonable. Please let me know if I can do anything to facilitate getting it merged.

Thanks!