### PR TITLE
Byte-encode state string in DefaultStorage Backend

### DIFF
--- a/maintenance_mode/backends.py
+++ b/maintenance_mode/backends.py
@@ -48,7 +48,7 @@ class DefaultStorageBackend(AbstractStateBackend):
         filename = settings.MAINTENANCE_MODE_STATE_FILE_NAME
         if default_storage.exists(filename):
             default_storage.delete(filename)
-        content = ContentFile(self.from_bool_to_str_value(value))
+        content = ContentFile(self.from_bool_to_str_value(value).encode())
         default_storage.save(filename, content)
 
 


### PR DESCRIPTION
This ensures that backends like S3 that only support byte objects can be used as well.

Closes #85 