### PR TITLE
Add backend for using default static storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ MAINTENANCE_MODE_STATE_BACKEND = "maintenance_mode.backends.LocalFileBackend"
 
 # alternatively it is possible to use the default storage backend
 MAINTENANCE_MODE_STATE_BACKEND = "maintenance_mode.backends.DefaultStorageBackend"
+
+# alternatively it is possible to use the static storage backend
+# make sure that STATIC_ROOT and SATIC_URL are also set
+MAINTENANCE_MODE_STATE_BACKEND = "maintenance_mode.backends.StaticStorageBackend"
 ```
 
 ```python

--- a/maintenance_mode/backends.py
+++ b/maintenance_mode/backends.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 from maintenance_mode.io import read_file, write_file
 
@@ -53,6 +54,27 @@ class DefaultStorageBackend(AbstractStateBackend):
             default_storage.delete(filename)
         content = ContentFile(self.from_bool_to_str_value(value).encode())
         default_storage.save(filename, content)
+
+
+class StaticStorageBackend(AbstractStateBackend):
+    """
+    django-maintenance-mode backend which uses the staticfiles storage.
+    """
+
+    def get_value(self):
+        filename = settings.MAINTENANCE_MODE_STATE_FILE_NAME
+        try:
+            with staticfiles_storage.open(filename, "r") as statefile:
+                return self.from_str_to_bool_value(statefile.read())
+        except IOError:
+            return False
+
+    def set_value(self, value):
+        filename = settings.MAINTENANCE_MODE_STATE_FILE_NAME
+        if staticfiles_storage.exists(filename):
+            staticfiles_storage.delete(filename)
+        content = ContentFile(self.from_bool_to_str_value(value).encode())
+        staticfiles_storage.save(filename, content)
 
 
 class LocalFileBackend(AbstractStateBackend):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -232,6 +232,27 @@ class MaintenanceModeTestCase(TestCase):
             "maintenance_mode.backends.LocalFileBackend"
         )
 
+    def test_backend_static_storage(self):
+
+        self.__reset_state()
+
+        settings.MAINTENANCE_MODE_STATE_BACKEND = (
+            "maintenance_mode.backends.StaticStorageBackend"
+        )
+
+        backend = core.get_maintenance_mode_backend()
+        self.assertEqual(backend.get_value(), False)
+
+        backend.set_value(True)
+        self.assertEqual(backend.get_value(), True)
+
+        backend.set_value(False)
+        self.assertEqual(backend.get_value(), False)
+
+        settings.MAINTENANCE_MODE_STATE_BACKEND = (
+            "maintenance_mode.backends.LocalFileBackend"
+        )
+
     def test_backend_custom_invalid(self):
 
         self.__reset_state()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -239,6 +239,8 @@ class MaintenanceModeTestCase(TestCase):
         settings.MAINTENANCE_MODE_STATE_BACKEND = (
             "maintenance_mode.backends.StaticStorageBackend"
         )
+        settings.STATIC_URL = "/static/"
+        settings.STATIC_ROOT = "static"
 
         backend = core.get_maintenance_mode_backend()
         self.assertEqual(backend.get_value(), False)


### PR DESCRIPTION
This PR adds the option to use the static backend to write the lock file. Exactly like DefaultStorageBackend but using the storage set for `static`.