### PR TITLE
Update Django version specifier in "Test package" workflow

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Install django
       run: |
-        pip install "Django ~= ${{ matrix.django-version }}.*"
+        pip install "Django == ${{ matrix.django-version }}.*"
 
     - name: Install requirements
       run: |

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Install django
       run: |
-        pip install "Django ~= ${{ matrix.django-version }}"
+        pip install "Django ~= ${{ matrix.django-version }}.*"
 
     - name: Install requirements
       run: |


### PR DESCRIPTION
**Describe your changes**

Hi ✋🏻 

I tried to adopt the excellent GH Action [fabiocaccamo/create-matrix-action@v2](https://github.com/marketplace/actions/create-matrix-action) in my project and found (at least I think so) a problem with Django version specifier used in one the job, see:

https://github.com/fabiocaccamo/django-maintenance-mode/blob/6c07c06a11e1cdd6931df02e0213c64bb6f4c8a0/.github/workflows/test-package.yml#L81

As far as I check, this does not result in installing a proper version. For example, in quite recent [run](https://github.com/fabiocaccamo/django-maintenance-mode/actions/runs/5387031940) `django ~= 4.1` installs `4.2.2`.

I guess a simple update to `django == 4.1.*` fixes that issue.

**Related issue**
n/a

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
